### PR TITLE
docker-compose syntax correction

### DIFF
--- a/docs/site-operations.md
+++ b/docs/site-operations.md
@@ -77,7 +77,7 @@ Change `SITES` variable to the list of sites created encapsulated in backtick an
 Reload variables with following command.
 
 ```sh
-docker-compose up --project-name <project-name> -d
+docker-compose --project-name <project-name> up -d
 ```
 
 ## Backup Sites


### PR DESCRIPTION
minor correction about docker-compose syntax. The "up -d" option must be at the end, so it is recognized as command.